### PR TITLE
Process objecttag subobjects of graphics object

### DIFF
--- a/filestructure.draft
+++ b/filestructure.draft
@@ -13,7 +13,7 @@ fonttable;font ;;
 font;;0 id s name ! charset ;
 arrow;;4 BoundingBox 0 color 3 Head3D 3 Tail3D 3 Center3D ! GraphicType ‼ LineType ! FillType ¢ AngularSize 3 MajorAxisEnd3D 3 MinorAxisEnd3D # ArrowheadType # ArrowheadHead # ArrowheadTail 0 Z 0 ArrowShaftSpacing ;
 line;;0 id 0 color 0 SupersededBy 4 BoundingBox 0 Z ! ArrowType ‼ LineType ;
-graphic;represent ;0 id 0 color 0 SupersededBy 4 BoundingBox 0 Z ! GraphicType ! ArrowType ! SymbolType 1 AngularSize 1 CornerRadius ‼ OvalType ‼ RectangleType ‼ LineType ! BracketType 3 Center3D 3 MajorAxisEnd3D 3 MinorAxisEnd3D : represent ;
+graphic;objecttag represent ;0 id 0 color 0 SupersededBy 4 BoundingBox 0 Z ! GraphicType ! ArrowType ! SymbolType 1 AngularSize 1 CornerRadius ‼ OvalType ‼ RectangleType ‼ LineType ! BracketType 3 Center3D 3 MajorAxisEnd3D 3 MinorAxisEnd3D : represent ;
 represent;;! attribute 0 object ;
 curve;;0 id 0 color 0 Z # ArrowheadType # ArrowheadHead # ArrowheadTail ~ CurvePoints ! FillType 0 CurveType ! Closed 0 FadePercent ;
 tlcplate;tlclane ;0 Z 0 id 0 color 2 TopLeft 2 TopRight 2 BottomRight 2 BottomLeft 1 OriginFraction 1 SolventFrontFraction ;


### PR DESCRIPTION
objecttag subobjects of graphics objects will no longer be ignored; this was
the cause of several rendering issues, such as missing bracket labels.